### PR TITLE
show upcoming events with jekyll 3 config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,9 @@ baseurl: "/dallas" # the subpath of your site, e.g. /blog/
 url: "http://nodeschool.github.io" # the base hostname & protocol for your site
 twitter_username: nodeschooldal
 
+# Publish future posts
+future: true
+
 # Build settings
 markdown: kramdown
 
@@ -22,6 +25,9 @@ libs:
   jquery: "lib/jquery-2.2.0.min.js"
   moment: "lib/moment-2.11.1.min.js"
   bootstrap: "lib/bootstrap-sass-3.3.6/assets"
+
+gems:
+  - jekyll-coffeescript
 
 defaults:
   -

--- a/_posts/2016-02-17-react.md
+++ b/_posts/2016-02-17-react.md
@@ -7,8 +7,8 @@ meetupId: 227528045
 
 ## Tonight's Featured Workshopper
 
-[learnyoureact](https://github.com/kohei-takata/learnyoureact) ➞ Learn React.js and server side rendering!
+[learnyoureact](https://github.com/kohei-takata/learnyoureact) → Learn React.js and server side rendering!
 
-```
+```bash
 npm install -g learnyoureact
 ```

--- a/_posts/2016-02-17-react.md
+++ b/_posts/2016-02-17-react.md
@@ -1,0 +1,14 @@
+---
+title: Don't Respond, React
+sponsors:
+- credera
+meetupId: 227528045
+---
+
+## Tonight's Featured Workshopper
+
+[learnyoureact](https://github.com/kohei-takata/learnyoureact) ➞ Learn React.js and server side rendering!
+
+```
+npm install -g learnyoureact
+```

--- a/_posts/2016-02-17-tbd.md
+++ b/_posts/2016-02-17-tbd.md
@@ -1,6 +1,0 @@
----
-title: Workshopper TBD
-sponsors:
-- credera
-meetupId: 227528045
----

--- a/_sass/_events.scss
+++ b/_sass/_events.scss
@@ -88,8 +88,8 @@
       &.js-relative-future-1 {
         .event-title {
           &:before {
-            color: #00bfff;
             content: 'Up Next:'
+            color: #00bfff;
           }
         }
       }

--- a/_sass/_events.scss
+++ b/_sass/_events.scss
@@ -74,19 +74,22 @@
         &:before {
           content: 'Far Far Away...';
           font-style: italic;
+          margin-right: 5px;
+          float: left;
         }
       }
       &.js-relative-future-2 {
         .event-title {
           &:before {
-            content: 'Coming Soon →'
+            content: 'Coming Soon...'
           }
         }
       }
       &.js-relative-future-1 {
         .event-title {
           &:before {
-            content: 'Up Next →'
+            color: #00bfff;
+            content: 'Up Next:'
           }
         }
       }
@@ -95,7 +98,6 @@
     &.js-relative-today, &.js-relative-future {
       .event-title {
         a {
-          margin-left: 5px;
           display: inline-block;
         }
       }

--- a/_sass/_events.scss
+++ b/_sass/_events.scss
@@ -140,6 +140,10 @@
         border-width: $ribbon-size-stacked;
         border-left-width: $ribbon-cutout-stacked;
       }
+
+      @media(max-width: $screen-xs-max) {
+        display: none;
+      }
     }
     &:before {
       left: $ribbon-horizontal-adjust;

--- a/_sass/_events.scss
+++ b/_sass/_events.scss
@@ -81,14 +81,14 @@
       &.js-relative-future-2 {
         .event-title {
           &:before {
-            content: 'Coming Soon...'
+            content: 'Coming Soon...';
           }
         }
       }
       &.js-relative-future-1 {
         .event-title {
           &:before {
-            content: 'Up Next:'
+            content: 'Up Next:';
             color: #00bfff;
           }
         }


### PR DESCRIPTION
Github updated to Jekyll 3 which requires a config flag of `future: true` to show upcoming posts. We want this so we can advertise upcoming events.

Also, this PR commits us to [learnyoureact](https://github.com/kohei-takata/learnyoureact). We cool with that?
